### PR TITLE
Switch to self-hosted machine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
   browser-tools: circleci/browser-tools@1.4.6
 jobs:
   build-and-test:
+    resource_class: talkingheads/localservers
     docker:
       - image: cimg/python:3.10.4
     steps:


### PR DESCRIPTION
Due to the problems regarding verification, the self-hosted runner is an option to run tests and ensure that the library works as expected.