### PR TITLE
ChatGPT fix, test coverage for claude and copilot, local server switch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           path: artifacts
       - codecov/upload:
           file: test-results/coverage.xml
-          token: $CODECOV_TOKEN
+          token: CODECOV_TOKEN
 workflows:
   base-tests:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,12 +28,14 @@ jobs:
           name: Run tests
           command: |
             mkdir test-results artifacts
-            python -m pytest --junitxml=test-results/junit.xml --cov talkingheads
+            python -m pytest --junitxml=test-results/junit.xml --cov=talkingheads --cov-report=xml:test-results/coverage.xml
       - store_test_results:
           path: test-results
       - store_artifacts:
           path: artifacts
-      - codecov/upload
+      - codecov/upload:
+          file: test-results/coverage.xml
+          token: $CODECOV_TOKEN
 workflows:
   base-tests:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,12 +23,12 @@ jobs:
           name: Install talkingheads and pytest
           command: |
             python -m pip install .
-            python -m pip install pytest psutil
+            python -m pip install pytest psutil pytest-cov
       - run:
           name: Run tests
           command: |
             mkdir test-results artifacts
-            python -m pytest --junitxml=test-results/junit.xml
+            python -m pytest --junitxml=test-results/junit.xml --cov app
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           name: Run tests
           command: |
             mkdir test-results artifacts
-            python -m pytest --junitxml=test-results/junit.xml --cov app
+            python -m pytest --junitxml=test-results/junit.xml --cov talkingheads
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,16 @@
 version: 2.1
 orbs:
   python: circleci/python@2.0.3
-  browser-tools: circleci/browser-tools@1.4.6
+  browser-tools: circleci/browser-tools@1.4.8
 jobs:
   build-and-test:
-    docker:
-      - image: cimg/python:3.10.4
     resource_class: talkingheads/localservers
+    docker:
+      - image: ugorsahin/talkingheads_test:v1
+        auth:
+          username: $DOCKER_UNAME
+          password: $DOCKER_PAT
+    working_directory: ~/project
     steps:
       - checkout
       - browser-tools/install-chrome
@@ -18,13 +22,19 @@ jobs:
           name: Install talkingheads and pytest
           command: |
             python -m pip install .
-            python -m pip install pytest
+            python -m pip install pytest psutil
       - run:
           name: Run tests
-          command: python -m pytest
+          command: |
+            mkdir test-results artifacts
+            python -m pytest --junitxml=test-results/junit.xml
       - store_test_results:
-          path: talkinghead-results
+          path: test-results
+      - store_artifacts:
+          path: artifacts
 workflows:
   base-tests:
     jobs:
-      - build-and-test
+      - build-and-test:
+          context:
+            - docker-hub-creds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,13 +28,13 @@ jobs:
           name: Run tests
           command: |
             mkdir test-results artifacts
-            python -m pytest --junitxml=test-results/junit.xml --cov=talkingheads --cov-report=xml:test-results/coverage.xml
+            python -m pytest --junitxml=test-results/junit.xml --cov=talkingheads --cov-report=xml:artifacts/coverage.xml
       - store_test_results:
           path: test-results
       - store_artifacts:
           path: artifacts
       - codecov/upload:
-          file: test-results/coverage.xml
+          file: artifacts/coverage.xml
           token: CODECOV_TOKEN
 workflows:
   base-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
   python: circleci/python@2.0.3
   browser-tools: circleci/browser-tools@1.4.8
+  codecov: codecov/codecov@4.0.1
 jobs:
   build-and-test:
     resource_class: talkingheads/localservers
@@ -32,6 +33,7 @@ jobs:
           path: test-results
       - store_artifacts:
           path: artifacts
+      - codecov/upload
 workflows:
   base-tests:
     jobs:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,5 @@
+- name: Upload coverage reports to Codecov
+  uses: codecov/codecov-action@v4.0.1
+  with:
+    token: ${{ secrets.CODECOV_TOKEN }}
+    slug: ugorsahin/TalkingHeads

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,0 @@
-- name: Upload coverage reports to Codecov
-  uses: codecov/codecov-action@v4.0.1
-  with:
-    token: ${{ secrets.CODECOV_TOKEN }}
-    slug: ugorsahin/TalkingHeads

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ MANIFEST
 
 # Sphinx
 _build
+
+# CircleCI
+artifacts

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@
   <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 
-Welcome to TalkingHeads! 🤖🚀
+Welcome to TalkingHeads! 💬
 
-TalkingHeads is a versatile Python library that serves as an interface for seamless communication with ChatGPT, Claude, Copilot, Gemini, HuggingChat, and Pi  🤖💬
+TalkingHeads is a versatile Python library that serves as an interface for seamless communication with ChatGPT, Claude, Copilot, Gemini, HuggingChat, and Pi  🤖
 
 By leveraging the power of browser automation, this library enables users to effortlessly interact with online LLM tools, providing a streamlined and automated approach to generate responses. 🚀✨
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
   <a href='https://github.com/ugorsahin/TalkingHeads/actions/workflows/codeql.yml'>
     <img src='https://github.com/ugorsahin/TalkingHeads/actions/workflows/codeql.yml/badge.svg' alt='CodeQL Status' />
   </a>
+  <a href="https://codecov.io/gh/ugorsahin/TalkingHeads" > 
+    <img src="https://codecov.io/gh/ugorsahin/TalkingHeads/graph/badge.svg?token=YPXKNXSZAD"/> 
+  </a>
   <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "talkingheads"
 description = "A library to communicate with ChatGPT, Claude, Copilot, Gemini, HuggingChat, and Pi"
 readme = "README.md"
 requires-python = ">=3.8"
-version = "0.4.1"
+version = "0.4.2"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",

--- a/src/talkingheads/base_browser.py
+++ b/src/talkingheads/base_browser.py
@@ -28,9 +28,9 @@ class BaseBrowser:
         url (str): The URL to be used as an entrypoint.
         uname_var (str): The username environment variable, to enable multiple agents.
         pwd_var (str): The password environment variable, to enable multiple agents.
-        username (str, optional): The username to auth. Deprecated. Use environment variables instead.
-        password (str, optional): The password to auth. Deprecated. Use environment variables instead.
-        headless (bool, optional): A boolean to enable/disable headless mode in driver. Default: True.
+        username (str, optional): Deprecated. Use environment variables instead.
+        password (str, optional): Deprecated. Use environment variables instead.
+        headless (bool, optional): Enables/disables headless mode. Default: True.
         cold_start (bool, optional): If set, it will return after opening the browser. Default: False.
         incognito (bool, optional): A boolean to set incognito mode. Default: True.
         driver_arguments (list, optional): A list of additional arguments to be passed to the driver. Default: None.
@@ -38,7 +38,7 @@ class BaseBrowser:
         auto_save (bool, optional): A boolean to enable/disable automatic saving. Default: False.
         save_path (str, optional): The file path to save chat logs. Default: None.
         verbose (bool, optional): A boolean to enable/disable logging. Default: False.
-        credential_check (bool, optional): A boolean to enable/disable credential check. Default: True.
+        credential_check (bool, optional): Enables/disables credential check. Default: True.
         skip_login (bool, optional): If True, skips the login procedure. Default: False.
         user_data_dir (str, optional): The directory path to user profile. Default: None.
         uc_params (dict, optional): Parameters for uc.Chrome().
@@ -147,6 +147,7 @@ class BaseBrowser:
         self.set_save_path(save_path)
 
     def __del__(self):
+        self.browser.close()
         self.browser.quit()
         if self.auto_save:
             self.save()
@@ -317,25 +318,15 @@ class BaseBrowser:
 
     def preload_custom_func(self) -> None:
         """
-        A function to implement specific instructions before loading the webpage
+        A function to implement custom instructions before loading the webpage
         """
-        logging.info(
-            """
-            The preload behavior is not implemented,
-            which could be considered normal if verification is not required.
-            """
-        )
+        logging.info("The preload behavior is not implemented")
 
     def postload_custom_func(self) -> None:
         """
-        A function to implement specific instructions after loading the webpage
+        A function to implement custom instructions after loading the webpage
         """
-        logging.info(
-            """
-            The postload behavior is not implemented,
-            which could be considered normal if verification is not required.
-            """
-        )
+        logging.info("The postload behavior is not implemented")
 
     def pass_verification(self) -> bool:
         """
@@ -343,12 +334,7 @@ class BaseBrowser:
         Returns:
             None
         """
-        logging.info(
-            """
-            Pass verification function is not implemented,
-            which could be considered normal if verification is not required.
-            """
-        )
+        logging.info("The pass verification function is not implemented")
         return True
 
     @abc.abstractmethod

--- a/src/talkingheads/model_library/chatgpt.py
+++ b/src/talkingheads/model_library/chatgpt.py
@@ -38,15 +38,14 @@ class ChatGPTClient(BaseBrowser):
         Returns: None
         """
         for _ in range(max_trial):
-            if not self.check_login_page():
-                break
             verify_button = self.browser.find_elements(By.ID, "challenge-stage")
-            if len(verify_button):
-                try:
-                    verify_button[0].click()
-                    logging.info("Clicked verification button")
-                except Exceptions.ElementNotInteractableException:
-                    logging.info("Verification button is not present or clickable")
+            if not verify_button:
+                break
+            try:
+                verify_button[0].click()
+                logging.info("Clicked verification button")
+            except Exceptions.ElementNotInteractableException:
+                logging.info("Verification button is not present or clickable")
             time.sleep(wait_time)
         else:
             logging.error("It is not possible to pass verification")
@@ -77,7 +76,7 @@ class ChatGPTClient(BaseBrowser):
         time.sleep(1)
 
         # Find email textbox, enter e-mail
-        email_box = self.wait_until_appear(By.ID, "username")
+        email_box = self.wait_until_appear(By.CLASS_NAME, self.markers.email_cq)
         email_box.send_keys(username)
         logging.info("Filled email box")
 
@@ -88,7 +87,7 @@ class ChatGPTClient(BaseBrowser):
         logging.info("Clicked continue button")
 
         # Find password textbox, enter password
-        pass_box = self.wait_until_appear(By.ID, "password")
+        pass_box = self.wait_until_appear(By.ID, self.markers.pwd_iq)
         pass_box.send_keys(password)
         logging.info("Filled password box")
         # Click continue

--- a/src/talkingheads/model_library/claude.py
+++ b/src/talkingheads/model_library/claude.py
@@ -1,5 +1,6 @@
 """Class definition for Claude client"""
 import logging
+import time
 
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
@@ -24,7 +25,7 @@ class ClaudeClient(BaseBrowser):
             **kwargs,
         )
 
-    def login(self, _1: str = None, _2: str = None):
+    def login(self, _1: str = None, _2: str = None) -> bool:
         """
         It is only possible to login Claude manually.
 
@@ -72,7 +73,7 @@ class ClaudeClient(BaseBrowser):
         text_area.send_keys(Keys.CONTROL + "a", Keys.DELETE)
         return True
 
-    def interact(self, prompt: str):
+    def interact(self, prompt: str) -> str:
         """Sends a prompt and retrieves the answer from the ChatGPT system.
 
         This function interacts with the Claude.
@@ -86,7 +87,7 @@ class ClaudeClient(BaseBrowser):
             prompt (str): The interaction text.
 
         Returns:
-            Dict[str]: The generated answer and references.
+            str: The generated answer.
         """
 
         text_area = self.find_or_fail(By.CLASS_NAME, self.markers.textarea_cq)
@@ -126,17 +127,18 @@ class ClaudeClient(BaseBrowser):
         """
         text_area = self.find_or_fail(By.CLASS_NAME, self.markers.textarea_cq)
         text_area.send_keys(Keys.CONTROL + "K")
-        start_button = self.find_or_fail(By.XPATH, self.markers.start_button_xq)
+        time.sleep(0.5)
+        start_button = self.wait_until_appear(By.XPATH, self.markers.start_button_xq)
         if not start_button:
             return False
         start_button.click()
 
         return True
 
-    def switch_model(self, _: str):
+    def switch_model(self, _: str) -> None:
         raise NotImplementedError("Claude only has one model")
 
-    def regenerate_response(self):
+    def regenerate_response(self) -> str:
         regen_button = self.find_or_fail(By.XPATH, self.markers.regen_xq)
         if not regen_button:
             return ""

--- a/src/talkingheads/object_map.py
+++ b/src/talkingheads/object_map.py
@@ -1,10 +1,13 @@
 """Storage of the xpath, class and id identifiers"""
+
 from easydict import EasyDict
 
 markers = EasyDict(
     {
         "ChatGPT": {
             "login_xq": '//button[//div[text()="Log in"]]',
+            "email_cq": "email-input",
+            "pwd_iq": "password",
             "continue_xq": '//button[text()="Continue"]',
             "tutorial_xq": '//div[contains(text(), "Okay, let’s go")]',
             "button_tq": "button",
@@ -72,12 +75,13 @@ markers = EasyDict(
             "welcome_tq": "cib-welcome-container",
             "tone_tq": "cib-tone-selector",
             "side_tq": "cib-side-panel",
+            "side_buttons_cq": "pivot",
             "plugin_tq": "cib-plugin-panel",
             "p_control_cq": "plugin-control",
             "new_chat_cq": "button-compose-content",
         },
         "Claude": {
-            "start_button_xq": '//div[text()="Start a new chat"]',
+            "start_button_xq": '//div[text()="Start Chat"]',
             "textarea_cq": "ProseMirror",
             "send_button_xq": '//button[@aria-label="Send Message"]',
             "chatarea_xq": '//div[contains(@class, "grid-cols-1")]/div[@class="contents"]',

--- a/tests/test_chatgpt.py
+++ b/tests/test_chatgpt.py
@@ -1,12 +1,13 @@
 """ChatGPT test"""
 
+import psutil
 import pytest
 from selenium.webdriver.common.by import By
 from talkingheads import ChatGPTClient
-
+from utils import get_driver_arguments
 
 def test_start():
-    pytest.chathead = ChatGPTClient(headless=True, verbose=True)
+    pytest.chathead = ChatGPTClient(**get_driver_arguments('chatgpt'))
     assert pytest.chathead.ready, "The Client is not ready"
 
 
@@ -54,5 +55,8 @@ def test_custom_interactions():
     ), f"Info text is different {applied_extra_text}"
 
 
-def pytest_sessionfinish(session, exitstatus):
+def test_delete_chathead():
     del pytest.chathead
+    assert not any(
+        "undetected_chromedriver" in p.name() for p in psutil.process_iter()
+    ), "Undetected chromedriver exists"

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1,0 +1,47 @@
+"""Claude test"""
+
+import time
+import psutil
+import pytest
+from selenium.webdriver.common.by import By
+from talkingheads import ClaudeClient
+from utils import get_driver_arguments
+
+def test_start():
+    pytest.chathead = ClaudeClient(**get_driver_arguments("claude", incognito=False))
+    assert pytest.chathead.ready, "The Client is not ready"
+
+def test_interaction():
+    time.sleep(1)
+    answer = pytest.chathead.interact(
+        "Without any explanation or extra information, just repeat the following: book."
+    )
+    answer_match = "book" in answer.lower()
+    assert (
+        answer_match
+    ), f'Answer is not "book.", instead it returned {answer}'
+
+def test_regenerate():
+    first_answer = pytest.chathead.interact(
+        "Without any explanation or extra information, type three animal names."
+    ).lower()
+    second_answer = pytest.chathead.regenerate_response()
+    assert first_answer != second_answer, "The regenerated answer is the same."
+
+
+def test_reset():
+    assert pytest.chathead.reset_thread()
+    time.sleep(1)
+    resp = pytest.chathead.find_or_fail(
+        By.XPATH, pytest.chathead.markers.chatarea_xq, return_type="last", fail_ok=True
+    )
+    assert (
+        resp is None
+    ), f"Chat is not empty {resp.text}"
+
+
+def test_delete_chathead():
+    del pytest.chathead
+    assert not any(
+        "undetected_chromedriver" in p.name() for p in psutil.process_iter()
+    ), "Undetected chromedriver exists"

--- a/tests/test_copilot.py
+++ b/tests/test_copilot.py
@@ -1,0 +1,62 @@
+"""Copilot test"""
+
+import time
+import psutil
+import pytest
+from talkingheads import CopilotClient
+from utils import get_driver_arguments
+
+def test_start():
+    pytest.chathead = CopilotClient(**get_driver_arguments('copilot', incognito=False))
+    assert pytest.chathead.ready, "The Client is not ready"
+
+
+def test_interaction():
+    time.sleep(1)
+    answer = pytest.chathead.interact(
+        "Without any explanation or extra information, just repeat the following: book."
+    )
+    assert (
+        "book" in answer.lower()
+    ), f'Answer is not "book.", instead it returned {answer}'
+
+def test_reset():
+    ch = pytest.chathead
+    answer = pytest.chathead.interact(
+        "Without any explanation or extra information, just repeat the following: student."
+    )
+    assert ch.reset_thread(), "Reset operation has failed."
+    greeting_text = ch.get_last_answer(check_greeting=True)
+    assert greeting_text != answer, "The last response is still the same."
+
+
+def test_model():
+    assert (
+        pytest.chathead.get_models(get_active_model=True) == "Balanced"
+    ), "Model is not balanced"
+    assert pytest.chathead.switch_model("Creative"), "Unable to switch to Creative"
+    assert (
+        pytest.chathead.get_models(get_active_model=True) == "Creative"
+    ), "Model is not Creative"
+    assert pytest.chathead.switch_model("Balanced"), "Unable to switch to Balanced"
+    assert (
+        pytest.chathead.get_models(get_active_model=True) == "Balanced"
+    ), "Model is not Balanced"
+
+
+def test_plugins():
+    ch = pytest.chathead
+    assert ch.toggle_plugin("Kayak"), "Couldn't enable Kayak plugin"
+    time.sleep(1)
+    assert ch.get_plugin("Kayak").is_selected(), "Kayak plugin is not enabled"
+    time.sleep(1)
+    assert ch.toggle_plugin("Kayak"), "Couldn't enable Kayak plugin"
+    time.sleep(1)
+    assert ch.get_plugin("Kayak"), "Kayak plugin is not disabled"
+
+
+def test_delete_chathead():
+    del pytest.chathead
+    assert not any(
+        "undetected_chromedriver" in p.name() for p in psutil.process_iter()
+    ), "Undetected chromedriver exists"

--- a/tests/test_huggingchat.py
+++ b/tests/test_huggingchat.py
@@ -1,13 +1,14 @@
 """HuggingChat test"""
 
 import time
+import psutil
 import pytest
 from selenium.webdriver.common.by import By
 from talkingheads import HuggingChatClient
-
+from utils import get_driver_arguments
 
 def test_start():
-    pytest.chathead = HuggingChatClient(headless=True, verbose=True)
+    pytest.chathead = HuggingChatClient(**get_driver_arguments('huggingchat'))
     assert pytest.chathead.ready, "The Client is not ready"
 
 
@@ -39,6 +40,8 @@ def test_reset():
     ), "Chat is not empty"
 
 
-def pytest_sessionfinish(_session, _exitstatus):
-    """exits"""
+def test_delete_chathead():
     del pytest.chathead
+    assert not any(
+        "undetected_chromedriver" in p.name() for p in psutil.process_iter()
+    ), "Undetected chromedriver exists"

--- a/tests/test_pi.py
+++ b/tests/test_pi.py
@@ -1,11 +1,13 @@
-"""HuggingChat test"""
+"""Pi test"""
 
 import time
+import psutil
 import pytest
 from talkingheads import PiClient
+from utils import get_driver_arguments
 
 def test_start():
-    pytest.chathead = PiClient(headless=True, verbose=True)
+    pytest.chathead = PiClient(**get_driver_arguments('pi'))
     assert pytest.chathead.ready, "The Client is not ready"
 
 
@@ -23,5 +25,8 @@ def test_interaction():
 #     assert pytest.chathead.switch_model("SupportPi"), "Model switch failed."
 
 
-def pytest_sessionfinish(session, exitstatus):
+def test_delete_chathead():
     del pytest.chathead
+    assert not any(
+        "undetected_chromedriver" in p.name() for p in psutil.process_iter()
+    ), "Undetected chromedriver exists"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,28 @@
+"""Utility functions for screen saving"""
+
+from typing import Dict, Any
+
+def get_driver_arguments(name: str, incognito: bool = True) -> Dict[str, Any]:
+    """Returns the parameters to start client
+
+    Args:
+        name (str): name of the client
+        incognito (bool, optional): Defaults to True.
+
+    Returns:
+        Dict[str, Any]: Arguments to the client
+    """
+
+    return {
+        "headless": True,
+        "verbose": True,
+        "driver_arguments": [
+            "--disable-dev-shm-usage",
+            "--enable-logging",
+            "--v=1",
+            f"--log-file=artifacts/{name}_chrome.log",
+            "--password-store=basic"
+        ],
+        "incognito" : incognito,
+        "user_data_dir" : "/home/circleci/talkingheads_userprofile"
+    }


### PR DESCRIPTION
Due to the implementation of more stringent bot detection measures, it is no longer feasible to conduct tests on CircleCI machines or other major CI/CD providers. Consequently, transitioning to a self-hosted runner has become a more viable alternative, despite the initial time and effort required for setup.
This minor release includes the following updates:

-  Resolved an issue that prevented ChatGPT from logging in due to the inability to locate the email input field.
-  Expanded test coverage to include Copilot and 
-  Addressed a bug that hindered Copilot's ability to toggle 
-  Rectified an emoji display issue on the README 
-  Corrected minor typographical errors in the 
-  Migrated testing to a local server 
-  Integrated Codecoverage